### PR TITLE
Test for overlap: some of them will fail with the current master

### DIFF
--- a/timespan_internal_test.go
+++ b/timespan_internal_test.go
@@ -1,0 +1,131 @@
+package spaniel
+
+import (
+	"testing"
+	"time"
+)
+
+var (
+	t1 = time.Date(2018, 1, 30, 0, 0, 0, 0, time.UTC)
+	t2 = t1.Add(time.Second)
+	t3 = t2.Add(time.Second)
+	t4 = t3.Add(time.Second)
+)
+
+func TestOverlap(t *testing.T) {
+	for _, tt := range []struct {
+		name                    string
+		a, b                    T
+		expectedNonContiguous   bool
+		expectedAllowContiguous bool
+	}{
+		{
+			//  [--a--]
+			//          [--b--]
+			name: "no overlap",
+			a:    NewEmpty(t1, t2),
+			b:    NewEmpty(t3, t4),
+			expectedNonContiguous:   false,
+			expectedAllowContiguous: false,
+		}, {
+			//  [--a--]
+			//        [--b--]
+			name: "contiguous",
+			a:    NewEmpty(t1, t2),
+			b:    NewEmpty(t2, t3),
+			expectedNonContiguous:   false,
+			expectedAllowContiguous: true,
+		}, {
+			//  [---a----]
+			//        [---b----]
+			name: "small intersection",
+			a:    NewEmpty(t1, t3),
+			b:    NewEmpty(t2, t4),
+			expectedNonContiguous:   true,
+			expectedAllowContiguous: true,
+		}, {
+			//  [------a------]
+			//      [--b--]
+			name: "one inside the other",
+			a:    NewEmpty(t1, t4),
+			b:    NewEmpty(t2, t3),
+			expectedNonContiguous:   true,
+			expectedAllowContiguous: true,
+		}, {
+			//  [--a--]
+			//  [--b--]
+			name: "same",
+			a:    NewEmpty(t1, t2),
+			b:    NewEmpty(t1, t2),
+			expectedNonContiguous:   true,
+			expectedAllowContiguous: true,
+		}, {
+			//  [--a--]
+			//           [b]
+			name: "span vs instant, no overlap",
+			a:    NewEmpty(t1, t3),
+			b:    NewEmpty(t4, t4),
+			expectedNonContiguous:   false,
+			expectedAllowContiguous: false,
+		}, {
+			//    [--a--]
+			//    [b]
+			name: "span vs instant, overlap on the start border",
+			a:    NewEmpty(t1, t3),
+			b:    NewEmpty(t1, t1),
+			expectedNonContiguous:   false,
+			expectedAllowContiguous: true,
+		}, {
+			//    [--a--]
+			//      [b]
+			name: "span vs instant, overlap in the middle",
+			a:    NewEmpty(t1, t3),
+			b:    NewEmpty(t2, t2),
+			expectedNonContiguous:   false,
+			expectedAllowContiguous: true,
+		}, {
+			//    [--a--]
+			//        [b]
+			name: "span vs instant, overlap at the end",
+			a:    NewEmpty(t1, t3),
+			b:    NewEmpty(t3, t3),
+			expectedNonContiguous:   false,
+			expectedAllowContiguous: true,
+		}, {
+			//    [a]
+			//         [b]
+			name: "both instants, no overlap",
+			a:    NewEmpty(t1, t1),
+			b:    NewEmpty(t2, t2),
+			expectedNonContiguous:   false,
+			expectedAllowContiguous: false,
+		}, {
+			//    [a]
+			//    [b]
+			name: "both instants, overlap",
+			a:    NewEmpty(t1, t1),
+			b:    NewEmpty(t1, t1),
+			expectedNonContiguous:   true,
+			expectedAllowContiguous: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			obtained := overlap(tt.a, tt.b, false)
+			if obtained != tt.expectedNonContiguous {
+				t.Errorf("in order, allowContiguous=false")
+			}
+			obtained = overlap(tt.b, tt.a, false)
+			if obtained != tt.expectedNonContiguous {
+				t.Errorf("reversed, allowContiguous=false")
+			}
+			obtained = overlap(tt.a, tt.b, true)
+			if obtained != tt.expectedAllowContiguous {
+				t.Errorf("in order, allowContiguous=true")
+			}
+			obtained = overlap(tt.b, tt.a, true)
+			if obtained != tt.expectedAllowContiguous {
+				t.Errorf("reversed, allowContiguous=true")
+			}
+		})
+	}
+}


### PR DESCRIPTION
I didn't think about timespans of length zero, but now that I have been thinking about them I have realized our overlap function is wrong in several cases: in this PR I have written a test for all the possible cases of overlap, and some of them are failing.

I haven't written a fix for overlap though, as before that we have to make a decision about zero-length timespans and what do they mean for the union and intersection operation (as they will be affected by the fix to overlap).

I believe this is something we must talk about before making a decision. First of all, please, take a look at the test, run them and let's think if what they say it is expected is actually rigth. (I have some doubts, specially about the "both instants, overlap" one)